### PR TITLE
Fix: Restore memory rules and align instruction files

### DIFF
--- a/.clinerules
+++ b/.clinerules
@@ -1,21 +1,26 @@
+# Rules from .clinerules:
 # Rules from:
 
+- **Repository Info**: This project resides in the `jakkaj/mcp-knowledge-graph-improved` GitHub repository. Use this for relevant GitHub operations.
 - General Rule: Always add debug output to tests if they are failing rather than guessing. Remember to clean up when it's working!
-- REMEMBER: YOU MUST READ THE GUIDE IF IT PERTAINS TO WHAT YOU ARE GOING TO DO!
+- **IMPORTANT**: Specific tasks often have detailed guidelines linked below. YOU MUST CONSULT these guides when your task relates to the corresponding topic to ensure correctness and adherence to project standards.
 
 ## Plan Structure Guidelines
-- If your task involves creating or modifying project plans or architectures, refer to the detailed guidelines in: `docs/guides/plan-structure-guidelines.md`
+- If your task involves creating or modifying project plans or architectures, **you MUST consult** the detailed guidelines in: `docs/guides/plan-structure-guidelines.md`
 
 ## Github Integration
-- For rules specific to interacting with GitHub issues, commits, and MCP tools within this project, refer to: `docs/guides/github-integration-rules.md`
-- Follow the conventional commits specification for all commits as outlined in the GitHub integration rules.
-- For detailed general guidance on working with GitHub workflows, PRs, and Git operations, refer to the comprehensive guide at: `docs/guides/github-workflow/llm-agent-github-guide.md`
+- For rules specific to interacting with GitHub issues, commits, and MCP tools within this project, **you MUST consult**: `docs/guides/github-integration-rules.md`
+- Follow the conventional commits specification for all commits as outlined in the GitHub integration rules guide.
+- For detailed general guidance on working with GitHub workflows, PRs, and Git operations, **you MUST consult** the comprehensive guide at: `docs/guides/github-workflow/llm-agent-github-guide.md`
+
+## Memory MCP Server Interaction
+- If your task involves interacting with the knowledge graph via the `memory` MCP server, **you MUST consult** the specific rules and best practices in: `docs/guides/memory-mcp-rules.md`
 
 ## Following Plans
-- If you are executing tasks based on an existing plan, refer to the rules for updating progress and handling tests in: `docs/guides/following-plans-rules.md`
+- If you are executing tasks based on an existing plan, **you MUST consult** the rules for updating progress and handling tests in: `docs/guides/following-plans-rules.md`
 
 ## Running Commands
-- If your task requires running build, test, or execution commands, refer to the guidelines (including using `make`) in: `docs/guides/running-commands-rules.md`
+- If your task requires running build, test, or execution commands, **you MUST consult** the guidelines (including using `make`) in: `docs/guides/running-commands-rules.md`
 
 ## Project Structure
-- For information about the project's source code location (`./src`) and build outputs (`./dist`), refer to: `docs/guides/project-structure-rules.md`
+- For information about the project's source code location (`./src`) and build outputs (`./dist`), **you MUST consult** the guide at: `docs/guides/project-structure-rules.md`

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,20 +1,26 @@
+# Rules from .clinerules:
 # Rules from:
 
+- **Repository Info**: This project resides in the `jakkaj/mcp-knowledge-graph-improved` GitHub repository. Use this for relevant GitHub operations.
 - General Rule: Always add debug output to tests if they are failing rather than guessing. Remember to clean up when it's working!
-- REMEMBER: YOU MUST READ THE GUIDE IF IT PERTAINS TO WHAT YOU ARE GOING TO DO!
+- **IMPORTANT**: Specific tasks often have detailed guidelines linked below. YOU MUST CONSULT these guides when your task relates to the corresponding topic to ensure correctness and adherence to project standards.
 
 ## Plan Structure Guidelines
-- If your task involves creating or modifying project plans or architectures, refer to the detailed guidelines in: `docs/guides/plan-structure-guidelines.md`
+- If your task involves creating or modifying project plans or architectures, **you MUST consult** the detailed guidelines in: `docs/guides/plan-structure-guidelines.md`
 
 ## Github Integration
-- For rules specific to interacting with GitHub issues, commits, and MCP tools within this project, refer to: `docs/guides/github-integration-rules.md`
-- For detailed general guidance on working with GitHub workflows, PRs, and Git operations, refer to the comprehensive guide at: `docs/guides/github-workflow/llm-agent-github-guide.md`
+- For rules specific to interacting with GitHub issues, commits, and MCP tools within this project, **you MUST consult**: `docs/guides/github-integration-rules.md`
+- Follow the conventional commits specification for all commits as outlined in the GitHub integration rules guide.
+- For detailed general guidance on working with GitHub workflows, PRs, and Git operations, **you MUST consult** the comprehensive guide at: `docs/guides/github-workflow/llm-agent-github-guide.md`
+
+## Memory MCP Server Interaction
+- If your task involves interacting with the knowledge graph via the `memory` MCP server, **you MUST consult** the specific rules and best practices in: `docs/guides/memory-mcp-rules.md`
 
 ## Following Plans
-- If you are executing tasks based on an existing plan, refer to the rules for updating progress and handling tests in: `docs/guides/following-plans-rules.md`
+- If you are executing tasks based on an existing plan, **you MUST consult** the rules for updating progress and handling tests in: `docs/guides/following-plans-rules.md`
 
 ## Running Commands
-- If your task requires running build, test, or execution commands, refer to the guidelines (including using `make`) in: `docs/guides/running-commands-rules.md`
+- If your task requires running build, test, or execution commands, **you MUST consult** the guidelines (including using `make`) in: `docs/guides/running-commands-rules.md`
 
 ## Project Structure
-- For information about the project's source code location (`./src`) and build outputs (`./dist`), refer to: `docs/guides/project-structure-rules.md`
+- For information about the project's source code location (`./src`) and build outputs (`./dist`), **you MUST consult** the guide at: `docs/guides/project-structure-rules.md`

--- a/docs/guides/memory-mcp-rules.md
+++ b/docs/guides/memory-mcp-rules.md
@@ -1,0 +1,13 @@
+# Memory MCP Server Interaction Rules
+
+When interacting with the `memory` MCP server for knowledge graph operations, adhere to the following:
+
+- **Purpose:** The `memory` server manages the project's knowledge graph, storing entities and their relationships.
+- **Tool Usage:** Use the `use_mcp_tool` tool with `server_name: memory`.
+- **Available Tools:** Familiarize yourself with the available tools like `create_entities`, `create_relations`, `add_observations`, `delete_entities`, `delete_observations`, `delete_relations`, `read_graph`, `search_nodes`, `open_nodes`, `update_entities`, `update_relations`. Refer to the MCP server details provided in the initial context for specific input schemas.
+- **Entity Naming:** Use clear and consistent names for entities.
+- **Relation Types:** Define meaningful relation types, typically using active voice verbs (e.g., "IMPLEMENTS", "USES", "DEFINES").
+- **Observations:** Add concise and relevant observations to entities to capture key details.
+- **Atomicity:** Prefer making multiple related changes (e.g., creating an entity and its relations) within a single `use_mcp_tool` call if the tool schema allows (like `create_entities` and `create_relations` accepting arrays), but break down complex updates into logical steps if necessary. Wait for confirmation after each step.
+- **Searching:** Use `search_nodes` to find existing entities before creating duplicates.
+- **Updates:** Use `update_entities` or `add_observations` to modify existing entities rather than deleting and recreating them unless necessary.


### PR DESCRIPTION
This PR addresses the issue where commit 14c43f6 inadvertently removed rules for the memory MCP server during simplification of instruction files.

- Restores memory server rules in a dedicated guide: `docs/guides/memory-mcp-rules.md`.
- Updates `.clinerules` to link to the new guide and strengthens the language for all guide links.
- Updates `.github/copilot-instructions.md` to align with `.clinerules`.
- Adds repository info (`jakkaj/mcp-knowledge-graph-improved`) to both instruction files for future reference.