### PR TITLE
fix(ci): add checks write permission for test reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      checks: write  # Added permission for test reporter
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
       issues: write
       pull-requests: write
       packages: write
+      checks: write  # Added permission for test reporter
     
     steps:
       - name: Checkout


### PR DESCRIPTION
## Fix for Test Result Reporting Permissions

This PR addresses the "Resource not accessible by integration" error seen in the GitHub Actions workflows when publishing test results.

### Changes Made
- Added `checks: write` permission to both CI and release workflows
- Ensures test results are properly displayed in the GitHub UI via the dorny/test-reporter action
- Fixes permission issues that prevented test reports from appearing in the workflow summary

### Technical Approach
The implementation adds the necessary `checks: write` permission that the dorny/test-reporter action requires to create check runs in GitHub. Without this permission, the action fails with a "Resource not accessible by integration" error.

### Testing Performed
- Verified the CI workflow runs successfully with the updated permissions
- Confirmed that test results are properly displayed in the GitHub UI

This PR completes the test result publishing implementation started in issue #8.

Relates to #8