### PR TITLE
Update release pipeline to use GitHub Container Registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,12 +96,12 @@ jobs:
         if: steps.semantic.outputs.new_release_published == 'true'
         uses: docker/setup-buildx-action@v3
       
-      - name: Login to Docker Hub
+      - name: Login to GitHub Container Registry
         if: steps.semantic.outputs.new_release_published == 'true'
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.GITHUB_USERNAME }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Extract version
         if: steps.semantic.outputs.new_release_published == 'true'
@@ -115,7 +115,7 @@ jobs:
           context: .
           push: true
           tags: |
-            jakkaj/mcp-knowledge-graph:${{ env.NEW_VERSION_TAG }}
-            jakkaj/mcp-knowledge-graph:latest
-          cache-from: type=registry,ref=jakkaj/mcp-knowledge-graph:latest
+            ghcr.io/jakkaj/mcp-knowledge-graph:${{ env.NEW_VERSION_TAG }}
+            ghcr.io/jakkaj/mcp-knowledge-graph:latest
+          cache-from: type=registry,ref=ghcr.io/jakkaj/mcp-knowledge-graph:latest
           cache-to: type=inline

--- a/README.md
+++ b/README.md
@@ -213,22 +213,22 @@ or using the Makefile:
 make docker-build
 ```
 
-#### Option 2: Pull the Image from Docker Hub
+#### Option 2: Pull the Image from GitHub Container Registry
 
-Alternatively, you can pull the pre-built image directly from Docker Hub:
+Alternatively, you can pull the pre-built image directly from GitHub Container Registry:
 
 ```bash
-docker pull jakkaj/mcp-knowledge-graph
+docker pull ghcr.io/jakkaj/mcp-knowledge-graph
 ```
 
 #### Run the Server
 
-Once you have the image (either built locally or pulled from Docker Hub), you can run the server. To persist memory to a local file, mount a directory from your host into the container. For example, to store memory in `.roo/memory.jsonl`:
+Once you have the image (either built locally or pulled from GitHub Container Registry), you can run the server. To persist memory to a local file, mount a directory from your host into the container. For example, to store memory in `.roo/memory.jsonl`:
 
 ```bash
 docker run -i --rm --init \
   -v $(pwd)/.roo:/data \
-  jakkaj/mcp-knowledge-graph \
+  ghcr.io/jakkaj/mcp-knowledge-graph \
   node dist/index.js --server --memory-path /data/memory.jsonl
 ```
 
@@ -241,7 +241,7 @@ You can adjust the mount path and memory file location as needed.
 
 ### Using with Roo and Cline (.roo/mcp.json)
 
-To use this MCP server with [Roo](https://github.com/modelcontextprotocol/roo) or [Cline](https://github.com/modelcontextprotocol/cline), configure your `.roo/mcp.json` file to point to the Dockerized server. Make sure to use the correct image name (`jakkaj/mcp-knowledge-graph`) whether you built it locally or pulled it.
+To use this MCP server with [Roo](https://github.com/modelcontextprotocol/roo) or [Cline](https://github.com/modelcontextprotocol/cline), configure your `.roo/mcp.json` file to point to the Dockerized server. Make sure to use the correct image name (`ghcr.io/jakkaj/mcp-knowledge-graph`) whether you built it locally or pulled it.
 
 #### Example `.roo/mcp.json`
 
@@ -257,7 +257,7 @@ To use this MCP server with [Roo](https://github.com/modelcontextprotocol/roo) o
         "--init",
         "-v",
         "/absolute/path/to/.roo:/data",
-        "jakkaj/mcp-knowledge-graph", // Use the correct image name
+        "ghcr.io/jakkaj/mcp-knowledge-graph", // Use the correct image name
         "node",
         "dist/index.js",
         "--server",


### PR DESCRIPTION
Update the release pipeline to use GitHub Container Registry instead of Docker Hub.

* **.github/workflows/release.yml**
  - Change the `Login to Docker Hub` step to `Login to GitHub Container Registry`.
  - Update the authentication method to use GitHub Actions' `GITHUB_TOKEN` instead of secrets.
  - Modify the `Build and push Docker image` step to use `ghcr.io` instead of `docker.io`.
  - Update the `tags` to use `ghcr.io/jakkaj/mcp-knowledge-graph`.

* **README.md**
  - Update the Docker pull command to use `ghcr.io` instead of `docker.io`.
  - Update the Docker run command to use `ghcr.io` instead of `docker.io`.
  - Modify instructions to reflect the use of GitHub Container Registry.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jakkaj/mcp-knowledge-graph-improved/pull/12?shareId=d43eb49c-22d1-4808-a960-733e067f2be5).