### PR TITLE
fix: correct GitHub Container Registry authentication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,8 @@ jobs:
         if: steps.semantic.outputs.new_release_published == 'true'
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.GITHUB_USERNAME }}
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Extract version


### PR DESCRIPTION
This PR fixes the GitHub Container Registry authentication issue in the release workflow.

## Changes
- Ensures proper authentication to GHCR using `github.repository_owner` as username
- Uses `registry: ghcr.io` to specify the correct container registry
- Maintains the use of `GITHUB_TOKEN` for authentication

This fix will enable the release workflow to properly publish Docker images to GitHub Container Registry when a new release is created.

Fixes #13